### PR TITLE
added condition to wait for machine to be active

### DIFF
--- a/intel_nfv_ci_tests/tests/scenario/test_numa_topology.py
+++ b/intel_nfv_ci_tests/tests/scenario/test_numa_topology.py
@@ -103,7 +103,7 @@ class TestServerNumaBase(manager.NetworkScenarioTest):
             flavor = self.create_flavor_with_numa()
         self.instance = self.create_server(
             image=self.image_ref,
-            flavor=flavor,
+            flavor=flavor,wait_until='ACTIVE',
             create_kwargs=create_kwargs)
 
     def verify_ssh(self):


### PR DESCRIPTION
Added condition to wait , so machine come in active state before allocating IP . Other wise it was not able to allocate IP and whole test was getting failed . 
